### PR TITLE
This fixes a bug where it would not load the contents of .gitignore under 5.2

### DIFF
--- a/PEAR/PackageFileManager/Git.php
+++ b/PEAR/PackageFileManager/Git.php
@@ -43,15 +43,15 @@ class PEAR_PackageFileManager_Git extends PEAR_PackageFileManager_File
         $git       = $this->_findGitRootDir($directory);
 
         if ($git) {
-            $content    = null;
+            $content = array();
             if ( file_exists($git.'.gitignore') ) {
-                $content .= file_get_contents($git.'.gitignore');
+                $content = array_merge($content,file($git.'.gitignore'));
             }
             if ( file_exists($git.'.git/info/exclude') ) {
-                $content   .=  file_get_contents($git.'.git/info/exclude');
+                $content = array_merge($content,file($git.'.git/info/exclude'));
             }
-            $content    = trim($content, "\n");
-            $content    = explode("\n", $content);
+            $content = array_map('rtrim',$content);
+
             $gitignore  = array('.git/*', '.gitignore');
             $gitinclude = array();
 


### PR DESCRIPTION
Specifically, the code `$content   .= file_exists($git.'.gitignore') AND file_get_contents($git.'.gitignore');` would append a `1` to `$content`.

I also changed it to load using file() in order fix a bug where the last line of .gitignore would be prepended to the first line of .git/info/exclude if the last line of .gitignore lacked a newline.
